### PR TITLE
Implement "Add Note" modal with form and category selection

### DIFF
--- a/src/components/editor/toolbar/AddNote.tsx
+++ b/src/components/editor/toolbar/AddNote.tsx
@@ -60,6 +60,7 @@ export const AddNote = ({ replayAction }: ToolbarItemProps) => {
 				<Checkbox
 					checked={checked}
 					onCheckedChange={() => setChecked(!checked)}
+					className="border-gray-500 hover:border-gray-400/95"
 				/>
 				Open in editor
 			</Label>

--- a/src/components/notelist/add-note-modal.tsx
+++ b/src/components/notelist/add-note-modal.tsx
@@ -1,0 +1,176 @@
+import { DialogContent, DialogHeader, DialogTitle } from "@/ui/dialog";
+import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
+import { ActiveNoteIdAtom, NotesAtom } from "@/store/note";
+import { menuSubject$, menuSubjectAtom } from "@/store";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { CategoriesAtom } from "@/store/category";
+import { useAtomValue, useSetAtom } from "jotai";
+import { generateNote } from "@/utils/helpers";
+import { useForm } from "react-hook-form";
+import { MenuEnum } from "@/utils/enums";
+import { Textarea } from "@/ui/textarea";
+import { Button } from "@/ui/button";
+import { Input } from "@/ui/input";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import {
+	CommandGroup,
+	CommandInput,
+	CommandEmpty,
+	CommandItem,
+	CommandList,
+	Command,
+} from "@/ui/command";
+import {
+	FormControl,
+	FormMessage,
+	FormField,
+	FormLabel,
+	FormItem,
+	Form,
+} from "@/ui/form";
+
+const FormSchema = z.object({
+	title: z.string().min(4, "Title is too short.").max(50, "Title is too long."),
+	content: z.string().optional(),
+	categoryId: z.string().optional(),
+});
+
+type AddNoteModalProps = {
+	handleClose: () => void;
+};
+
+type Schema = z.infer<typeof FormSchema>;
+
+export const AddNoteModal = ({ handleClose }: AddNoteModalProps) => {
+	const form = useForm<Schema>({
+		resolver: zodResolver(FormSchema),
+	});
+
+	const setNotes = useSetAtom(NotesAtom);
+	const categories = useAtomValue(CategoriesAtom);
+	const activeMenu = useAtomValue(menuSubjectAtom);
+	const setActiveNoteId = useSetAtom(ActiveNoteIdAtom);
+
+	const handleSubmit = ({ title, content, categoryId }: Schema) => {
+		const note = generateNote({ title, content, categoryId, trash: false });
+		setNotes((notes) => [...notes, note]);
+		if (activeMenu !== MenuEnum.notes) menuSubject$.next(MenuEnum.notes);
+		setActiveNoteId(note.id);
+		toast.success("Note Created!");
+		handleClose();
+	};
+
+	return (
+		<DialogContent className="max-w-[360px] p-0 pt-4 dark:bg-neutral-900">
+			<DialogHeader className="px-4">
+				<DialogTitle className="text-base leading-5">New Note</DialogTitle>
+			</DialogHeader>
+			<Form {...form}>
+				<form
+					onSubmit={form.handleSubmit(handleSubmit)}
+					className="flex flex-col gap-y-5 px-4 pb-4"
+				>
+					<FormField
+						name="title"
+						control={form.control}
+						render={({ field }) => (
+							<FormItem className="space-y-1">
+								<FormControl>
+									<Input
+										className="border-b focus:border-b-neutral-700"
+										placeholder="Add title here..."
+										{...field}
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+
+					<FormField
+						name="content"
+						control={form.control}
+						render={({ field }) => (
+							<FormItem className="mt-3 flex flex-col gap-y-0.5">
+								<FormLabel>Content</FormLabel>
+								<FormControl>
+									<Textarea
+										className="focus:ring-neutral-700"
+										placeholder="Note content here..."
+										{...field}
+									/>
+								</FormControl>
+							</FormItem>
+						)}
+					/>
+
+					<FormField
+						name="categoryId"
+						control={form.control}
+						render={({ field }) => (
+							<FormItem className="flex w-[200px] flex-col">
+								<FormLabel>Category</FormLabel>
+								<Popover>
+									<PopoverTrigger asChild>
+										<FormControl>
+											<Button
+												variant="outline"
+												role="combobox"
+												className={cn(
+													"w-[200px] justify-between dark:bg-neutral-900",
+													!field.value && "text-muted-foreground",
+												)}
+											>
+												{field.value
+													? categories.find(
+															(category) => category.id === field.value,
+														)?.text
+													: "Select Category"}
+												<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+											</Button>
+										</FormControl>
+									</PopoverTrigger>
+									<PopoverContent className="w-[200px] p-0">
+										<Command className="dark:bg-neutral-900">
+											<CommandInput placeholder="Search category..." />
+											<CommandList>
+												<CommandEmpty>No category found.</CommandEmpty>
+												<CommandGroup>
+													{categories.map(({ id, text }) => (
+														<CommandItem
+															key={id}
+															value={text}
+															onSelect={() => form.setValue("categoryId", id)}
+														>
+															<Check
+																className={cn(
+																	"mr-2 h-4 w-4",
+																	id === field.value
+																		? "opacity-100"
+																		: "opacity-0",
+																)}
+															/>
+															{text}
+														</CommandItem>
+													))}
+												</CommandGroup>
+											</CommandList>
+										</Command>
+									</PopoverContent>
+								</Popover>
+							</FormItem>
+						)}
+					/>
+
+					<Button type="submit" variant="default">
+						Add
+					</Button>
+				</form>
+			</Form>
+		</DialogContent>
+	);
+};

--- a/src/components/notelist/layout.tsx
+++ b/src/components/notelist/layout.tsx
@@ -5,6 +5,7 @@
 import type { NoteItem } from "@/types";
 
 import { ActiveNoteIdAtom, IncludeTrashAtom, NotesAtom } from "@/store/note";
+import { filterNotesByFolder, mapMenuToFolder } from "@/utils/helpers";
 import { LayoutGroup, Reorder, AnimatePresence } from "framer-motion";
 import { SearchIcon, SendHorizonal } from "lucide-react";
 import { categoryStateAtom } from "@/store/category";
@@ -16,11 +17,6 @@ import { menuSubjectAtom } from "@/store";
 import { InputBlock } from "@/ui/input";
 import { Folder } from "@/utils/enums";
 import { ListItem, Toolbar } from ".";
-import {
-	filterNotesByFolder,
-	generateFakeNotes,
-	mapMenuToFolder,
-} from "@/utils/helpers";
 
 const MemoizedListItem = memo(ListItem);
 

--- a/src/components/notelist/toolbar.tsx
+++ b/src/components/notelist/toolbar.tsx
@@ -1,12 +1,14 @@
 import type { Menus } from "@/types";
 
 import { SlideInAnimationVariants } from "@/utils/motion";
+import { AddNoteModal } from "@/notelist/add-note-modal";
 import { AnimatePresence, motion } from "framer-motion";
+import { Dialog, DialogTrigger } from "@/ui/dialog";
+import { Plus, TrashIcon } from "lucide-react";
+import { useCallback, useState } from "react";
 import { MenuEnum } from "@/utils/enums";
-import { TrashIcon } from "lucide-react";
 import { Checkbox } from "@/ui/checkbox";
 import { Button } from "@/ui/button";
-import { useCallback } from "react";
 import { Label } from "@/ui/label";
 import {
 	AlertDialogDescription,
@@ -19,6 +21,8 @@ import {
 	AlertDialogTitle,
 	AlertDialog,
 } from "@/ui/alert-dialog";
+
+import useMousetrap from "use-mousetrap";
 
 interface ToolbarProps {
 	activeMenu: Menus;
@@ -39,8 +43,14 @@ export const Toolbar = (props: ToolbarProps) => {
 		[onIncludeTrashChange],
 	);
 
+	const [open, setOpen] = useState(false);
+
+	const handleOpen = () => !open && setOpen(true);
+
+	useMousetrap("command+k", handleOpen);
+
 	return (
-		<div className="flex h-14 items-center justify-start bg-neutral-900 px-4">
+		<div className="flex h-14 items-center justify-between gap-x-4 bg-neutral-100 px-4 dark:bg-neutral-900">
 			<AnimatePresence>
 				{activeMenu === MenuEnum.notes && (
 					<motion.div
@@ -48,21 +58,26 @@ export const Toolbar = (props: ToolbarProps) => {
 						initial="hidden"
 						animate="visible"
 						exit="exit"
-						className="flex w-full cursor-pointer items-center justify-end gap-2 text-xs text-gray-500"
+						className="flex w-full cursor-pointer items-center gap-2 text-xs text-gray-500"
 					>
 						<Checkbox
 							id="terms"
-							className="border-gray-500"
+							className="border-gray-500 hover:border-gray-400/95"
 							checked={isIncludeTrashChecked}
 							onCheckedChange={handleCheckChange}
 						/>
-						<Label htmlFor="terms">Include trash</Label>
+						<Label
+							htmlFor="terms"
+							className="cursor-pointer text-gray-500 hover:text-gray-400/95"
+						>
+							Include trash
+						</Label>
 					</motion.div>
 				)}
 
 				{activeMenu === MenuEnum.trash && (
 					<motion.div
-						className="flex w-full items-center justify-end"
+						className="flex w-full items-center"
 						variants={SlideInAnimationVariants}
 						initial="hidden"
 						animate="visible"
@@ -98,6 +113,19 @@ export const Toolbar = (props: ToolbarProps) => {
 						</AlertDialog>
 					</motion.div>
 				)}
+
+				<Dialog open={open} onOpenChange={setOpen}>
+					<DialogTrigger asChild>
+						<Button
+							variant="ghost"
+							className="ml-auto justify-end bg-transparent px-0 text-gray-500 hover:bg-neutral-900/90 hover:text-gray-400/95"
+						>
+							<Plus className="mr-1.5 h-4 w-4" />
+							Create Note
+						</Button>
+					</DialogTrigger>
+					<AddNoteModal handleClose={() => setOpen(false)} />
+				</Dialog>
 			</AnimatePresence>
 		</div>
 	);

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -16,13 +16,16 @@ const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = forwardRef<
 	React.ElementRef<typeof DialogPrimitive.Overlay>,
-	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> & {
+		showOVerlay?: boolean;
+	}
+>(({ className, showOVerlay = true, ...props }, ref) => (
 	<DialogPrimitive.Overlay
 		ref={ref}
 		className={cn(
-			"fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+			"fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
 			className,
+			{ "bg-black/30": showOVerlay },
 		)}
 		{...props}
 	/>
@@ -31,10 +34,12 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = forwardRef<
 	React.ElementRef<typeof DialogPrimitive.Content>,
-	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+		showOverlay?: boolean;
+	}
+>(({ className, showOverlay, children, ...props }, ref) => (
 	<DialogPortal>
-		<DialogOverlay />
+		<DialogOverlay showOVerlay={showOverlay} />
 		<DialogPrimitive.Content
 			ref={ref}
 			className={cn(

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import * as LabelPrimitive from "@radix-ui/react-label";
+import {
+	ControllerProps,
+	useFormContext,
+	FormProvider,
+	FieldValues,
+	Controller,
+	FieldPath,
+} from "react-hook-form";
+
+import { forwardRef, createContext, useContext, useId } from "react";
+import { Label } from "@/components/ui/label";
+import { Slot } from "@radix-ui/react-slot";
+import { cn } from "@/lib/utils";
+
+const Form = FormProvider;
+
+type FormFieldContextValue<
+	TFieldValues extends FieldValues = FieldValues,
+	TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+	name: TName;
+};
+
+const FormFieldContext = createContext<FormFieldContextValue>(
+	{} as FormFieldContextValue,
+);
+
+const FormField = <
+	TFieldValues extends FieldValues = FieldValues,
+	TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+	...props
+}: ControllerProps<TFieldValues, TName>) => {
+	return (
+		<FormFieldContext.Provider value={{ name: props.name }}>
+			<Controller {...props} />
+		</FormFieldContext.Provider>
+	);
+};
+
+const useFormField = () => {
+	const fieldContext = useContext(FormFieldContext);
+	const itemContext = useContext(FormItemContext);
+	const { getFieldState, formState } = useFormContext();
+
+	const fieldState = getFieldState(fieldContext.name, formState);
+
+	if (!fieldContext) {
+		throw new Error("useFormField should be used within <FormField>");
+	}
+
+	const { id } = itemContext;
+
+	return {
+		id,
+		name: fieldContext.name,
+		formItemId: `${id}-form-item`,
+		formDescriptionId: `${id}-form-item-description`,
+		formMessageId: `${id}-form-item-message`,
+		...fieldState,
+	};
+};
+
+type FormItemContextValue = {
+	id: string;
+};
+
+const FormItemContext = createContext<FormItemContextValue>(
+	{} as FormItemContextValue,
+);
+
+const FormItem = forwardRef<
+	HTMLDivElement,
+	React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+	const id = useId();
+
+	return (
+		<FormItemContext.Provider value={{ id }}>
+			<div ref={ref} className={cn("space-y-2", className)} {...props} />
+		</FormItemContext.Provider>
+	);
+});
+FormItem.displayName = "FormItem";
+
+const FormLabel = forwardRef<
+	React.ElementRef<typeof LabelPrimitive.Root>,
+	React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+	const { error, formItemId } = useFormField();
+
+	return (
+		<Label
+			ref={ref}
+			className={cn(error && "text-destructive", className)}
+			htmlFor={formItemId}
+			{...props}
+		/>
+	);
+});
+FormLabel.displayName = "FormLabel";
+
+const FormControl = forwardRef<
+	React.ElementRef<typeof Slot>,
+	React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+	const { error, formItemId, formDescriptionId, formMessageId } =
+		useFormField();
+
+	return (
+		<Slot
+			ref={ref}
+			id={formItemId}
+			aria-describedby={
+				!error
+					? `${formDescriptionId}`
+					: `${formDescriptionId} ${formMessageId}`
+			}
+			aria-invalid={!!error}
+			{...props}
+		/>
+	);
+});
+FormControl.displayName = "FormControl";
+
+const FormDescription = forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+	const { formDescriptionId } = useFormField();
+
+	return (
+		<p
+			ref={ref}
+			id={formDescriptionId}
+			className={cn("text-[0.8rem] text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+});
+FormDescription.displayName = "FormDescription";
+
+const FormMessage = forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+	const { error, formMessageId } = useFormField();
+	const body = error ? String(error?.message) : children;
+
+	if (!body) {
+		return null;
+	}
+
+	return (
+		<p
+			ref={ref}
+			id={formMessageId}
+			className={cn("text-[0.8rem] font-medium text-destructive", className)}
+			{...props}
+		>
+			{body}
+		</p>
+	);
+});
+FormMessage.displayName = "FormMessage";
+
+export {
+	useFormField,
+	Form,
+	FormItem,
+	FormLabel,
+	FormControl,
+	FormDescription,
+	FormMessage,
+	FormField,
+};

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface TextareaProps
+	extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+	({ className, ...props }, ref) => {
+		return (
+			<textarea
+				className={cn(
+					"flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-neutral-600 dark:focus-visible:ring-neutral-700",
+					className,
+				)}
+				ref={ref}
+				{...props}
+			/>
+		);
+	},
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };


### PR DESCRIPTION
### TL;DR

Added a new "Add Note" feature with a modal dialog and updated the toolbar UI.

### What changed?

- Created a new `AddNoteModal` component for adding notes.
- Updated the `Toolbar` component to include an "Add Note" button.
- Modified the `Dialog` component to support an optional overlay.
- Added new form-related components (`Form`, `FormField`, `FormItem`, etc.).
- Implemented a new `Textarea` component.
- Updated styling for various UI elements.

### How to test?

1. Open the application and navigate to the notes list.
2. Click the "Create Note" button in the toolbar.
3. Fill out the form in the modal, including title, content, and category.
4. Submit the form and verify that a new note is created.
5. Check that the new note appears in the list and opens in the editor.
6. Verify that the keyboard shortcut "command+k" also opens the "Add Note" modal.

### Why make this change?

This change improves the user experience by providing a quick and easy way to add new notes directly from the note list view. The modal approach allows users to create notes without leaving their current context, and the addition of categories and content fields in the creation process gives users more control over their note organization from the start.

---

