### PR TITLE
Implement expandable toolbar toggle in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"@radix-ui/react-progress": "^1.1.0",
 		"@radix-ui/react-separator": "^1.1.0",
 		"@radix-ui/react-slot": "^1.1.0",
+		"@radix-ui/react-switch": "^1.1.0",
 		"@radix-ui/react-tabs": "^1.1.0",
 		"@radix-ui/react-toggle": "^1.1.0",
 		"@radix-ui/react-tooltip": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.2.57)(react@18.3.1)
+      '@radix-ui/react-switch':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-tabs':
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1234,6 +1237,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.1.0':
+    resolution: {integrity: sha512-OBzy5WAj641k0AOSpKQtreDMe+isX0MQJ1IVyF03ucdF3DunOnROVrjWs8zsXUxC3zfZ6JL9HFVCUlMghz9dJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-tabs@1.1.0':
@@ -5127,6 +5143,21 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.2.57
+
+  '@radix-ui/react-switch@1.1.0(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.57)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.2.57)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.57)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.2.57)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.2.57)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.57
+      '@types/react-dom': 18.2.19
 
   '@radix-ui/react-tabs@1.1.0(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:

--- a/src/components/editor/Wrapper.tsx
+++ b/src/components/editor/Wrapper.tsx
@@ -2,6 +2,7 @@
 
 import { ExpandableToolbar } from "@/editor/ExpandableToolbar";
 import { EmptyEditor } from "@/components/editor/EmptyEditor";
+import { ShowExpandableToolbarAtom } from "@/store/setting";
 import { ResizablePanel } from "@/components/ui/resizable";
 import { NoteEditor } from "@/editor/NoteEditor";
 import { ActiveNoteIdAtom } from "@/store/note";
@@ -12,6 +13,7 @@ import { useAtomValue } from "jotai";
 export const EditorWrapper = () => {
 	const activeMenu = useAtomValue(menuSubjectAtom);
 	const activeNoteId = useAtomValue(ActiveNoteIdAtom);
+	const showToolbar = useAtomValue(ShowExpandableToolbarAtom);
 
 	const showEditor = activeMenu === MenuEnum.scratchpad || activeNoteId;
 
@@ -21,7 +23,7 @@ export const EditorWrapper = () => {
 			className="relative bg-neutral-200 p-4 dark:bg-neutral-900"
 		>
 			{showEditor ? <NoteEditor /> : <EmptyEditor />}
-			<ExpandableToolbar />
+			{showToolbar && <ExpandableToolbar />}
 		</ResizablePanel>
 	);
 };

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -2,6 +2,7 @@
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/ui/tabs";
 import { KeyboardShortcuts } from "@/settings/keyboard-shortcuts";
+import { Preferences } from "@/settings/preferences";
 import { TabsGroup } from "@/lib/constants";
 import { Settings2 } from "lucide-react";
 import { Button } from "@/ui/button";
@@ -57,10 +58,8 @@ export const Settings = () => {
 						))}
 					</TabsList>
 
-					<TabsContent value="preferences" className="mt-0">
-						<div className="ml-4 flex flex-col gap-y-2">
-							<h3 className="text-lg font-semibold">Preferences</h3>
-						</div>
+					<TabsContent value="preferences" className="mt-0 w-full">
+						<Preferences />
 					</TabsContent>
 
 					<TabsContent value="keyboard-shortcuts" className="mt-0 w-full">

--- a/src/components/settings/preferences.tsx
+++ b/src/components/settings/preferences.tsx
@@ -1,0 +1,20 @@
+import { ShowExpandableToolbarAtom } from "@/store/setting";
+import { Switch } from "@/ui/switch";
+import { Label } from "@/ui/label";
+import { useAtom } from "jotai";
+
+export const Preferences = () => {
+	const [showToolbar, setShowToolbar] = useAtom(ShowExpandableToolbarAtom);
+
+	return (
+		<div className="ml-4 flex flex-col gap-y-2">
+			<h3 className="text-lg font-semibold">Preferences</h3>
+			<div className="flex flex-col gap-y-2 divide-y divide-zinc-700/10">
+				<Label className="flex items-center justify-between gap-x-2 text-sm font-medium leading-6 text-zinc-800">
+					<span>Show / Hide Expandable Toolbar</span>
+					<Switch checked={showToolbar} onCheckedChange={setShowToolbar} />
+				</Label>
+			</div>
+		</div>
+	);
+};

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+const Switch = forwardRef<
+	React.ElementRef<typeof SwitchPrimitives.Root>,
+	React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+	<SwitchPrimitives.Root
+		className={cn(
+			"peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+			className,
+		)}
+		{...props}
+		ref={ref}
+	>
+		<SwitchPrimitives.Thumb
+			className={cn(
+				"pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+			)}
+		/>
+	</SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -1,0 +1,12 @@
+import type { SettingsState } from "@/types";
+
+import { atomWithStorage } from "jotai/utils";
+import { focusAtom } from "jotai-optics";
+
+export const settingStateAtom = atomWithStorage<SettingsState>("setting", {
+	showExpandableToolbar: true,
+});
+
+export const ShowExpandableToolbarAtom = focusAtom(settingStateAtom, (optics) =>
+	optics.prop("showExpandableToolbar"),
+);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,12 +78,7 @@ export interface NoteState {
 }
 
 export interface SettingsState {
-	isOpen: boolean;
-	loading: boolean;
-	darkTheme: boolean;
-	sidebarVisible: boolean;
-	previewMarkdown: boolean;
-	codeMirrorOptions: { [key: string]: any };
+	showExpandableToolbar: boolean;
 }
 
 export interface SyncState {


### PR DESCRIPTION
### TL;DR

Added a toggle for showing/hiding the expandable toolbar in the editor.

### What changed?

- Introduced a new `ShowExpandableToolbarAtom` in the settings store
- Created a new `Preferences` component for the settings dialog
- Added a switch component to toggle the expandable toolbar visibility
- Updated the `EditorWrapper` to conditionally render the `ExpandableToolbar` based on the new setting
- Simplified the `SettingsState` interface to focus on the new toolbar visibility option

### How to test?

1. Open the application and navigate to the settings dialog
2. Go to the "Preferences" tab
3. Locate the "Show / Hide Expandable Toolbar" switch
4. Toggle the switch on and off
5. Verify that the expandable toolbar in the editor appears and disappears accordingly

### Why make this change?

This change provides users with more control over their editing experience. Some users may prefer a cleaner interface without the expandable toolbar, while others may find it useful. By making this a configurable option, we cater to different user preferences and improve overall user experience.

---

