### PR TITLE
Implement delete category with notes option in settings

### DIFF
--- a/src/components/settings/preferences.tsx
+++ b/src/components/settings/preferences.tsx
@@ -1,18 +1,28 @@
-import { ShowExpandableToolbarAtom } from "@/store/setting";
 import { Switch } from "@/ui/switch";
 import { Label } from "@/ui/label";
 import { useAtom } from "jotai";
 
+import {
+	ShowExpandableToolbarAtom,
+	DeleteWithNotesAtom,
+} from "@/store/setting";
+
 export const Preferences = () => {
 	const [showToolbar, setShowToolbar] = useAtom(ShowExpandableToolbarAtom);
+	const [WithNotes, setWithNotes] = useAtom(DeleteWithNotesAtom);
 
 	return (
 		<div className="ml-4 flex flex-col gap-y-2">
 			<h3 className="text-lg font-semibold">Preferences</h3>
-			<div className="flex flex-col gap-y-2 divide-y divide-zinc-700/10">
+			<div className="flex flex-col gap-y-2">
 				<Label className="flex items-center justify-between gap-x-2 text-sm font-medium leading-6 text-zinc-800">
 					<span>Show / Hide Expandable Toolbar</span>
 					<Switch checked={showToolbar} onCheckedChange={setShowToolbar} />
+				</Label>
+
+				<Label className="flex items-center justify-between gap-x-2 text-sm font-medium leading-6 text-zinc-800">
+					<span>Deleting a category include notes associated with it</span>
+					<Switch checked={WithNotes} onCheckedChange={setWithNotes} />
 				</Label>
 			</div>
 		</div>

--- a/src/components/sidebar/layout.tsx
+++ b/src/components/sidebar/layout.tsx
@@ -8,6 +8,7 @@ import { CategoriesAtom, activeCategoryIdAtom } from "@/store/category";
 import { AnimatePresence, LayoutGroup, Reorder } from "framer-motion";
 import { memo, useCallback, useState, useRef } from "react";
 import { menuSubject$, menuSubjectAtom } from "@/store";
+import { DeleteWithNotesAtom } from "@/store/setting";
 import { CategoryListItem } from "@/sidebar/listitem";
 import { CategorySchema } from "@/utils/constants";
 import { useAtom, useAtomValue } from "jotai";
@@ -41,6 +42,7 @@ export default function Layout() {
 	const [showDialog, setShowDialog] = useState(false);
 
 	const activeMenu = useAtomValue(menuSubjectAtom);
+	const withNotes = useAtomValue(DeleteWithNotesAtom);
 
 	const handleClickItem = useCallback((id: string) => {
 		if (activeMenu !== MenuEnum.categories)
@@ -89,16 +91,16 @@ export default function Layout() {
 	useMousetrap("command+m", handlePopup);
 
 	return (
-		<section className="flex h-full w-full max-w-[17rem] flex-col gap-y-4 border-r dark:bg-neutral-900 px-4">
+		<section className="flex h-full w-full max-w-[17rem] flex-col gap-y-4 border-r px-4 dark:bg-neutral-900">
 			<MenuBar />
 			<div className="mt-4 flex flex-col">
 				<div className="flex items-center justify-between gap-x-2">
-					<h3 className="px-2 text-xs uppercase font-semibold tracking-wider dark:text-zinc-600 transition-colors duration-300 dark:hover:text-zinc-500">
+					<h3 className="px-2 text-xs font-semibold uppercase tracking-wider transition-colors duration-300 dark:text-zinc-600 dark:hover:text-zinc-500">
 						Categories
 					</h3>
 					<Button
 						variant="ghost"
-						className="dark:text-gray-600 hover:bg-transparent dark:hover:text-gray-500"
+						className="hover:bg-transparent dark:text-gray-600 dark:hover:text-gray-500"
 						onClick={handlePopup}
 					>
 						<span className="sr-only">Add Category</span>
@@ -117,7 +119,7 @@ export default function Layout() {
 							{showDialog && (
 								<MenuItem
 									icon="Folder"
-									className="w-full dark:bg-neutral-800/5 text-sm capitalize dark:shadow bg-neutral-200 shadow-sm"
+									className="w-full bg-neutral-200 text-sm capitalize shadow-sm dark:bg-neutral-800/5 dark:shadow"
 								>
 									<Input
 										autoFocus
@@ -158,8 +160,9 @@ export default function Layout() {
 						<AlertDialogHeader>
 							<AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
 							<AlertDialogDescription>
-								This action cannot be undone. This will permanently delete and
-								remove your data from our servers.
+								This action cannot be undone. This will permanently delete this
+								category with ID <strong>{selectedId}</strong>{" "}
+								{withNotes && "and all associated notes"}.
 							</AlertDialogDescription>
 						</AlertDialogHeader>
 						<AlertDialogFooter>

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -5,8 +5,14 @@ import { focusAtom } from "jotai-optics";
 
 export const settingStateAtom = atomWithStorage<SettingsState>("setting", {
 	showExpandableToolbar: true,
+	deleteCategoryWithNotes: false,
 });
 
 export const ShowExpandableToolbarAtom = focusAtom(settingStateAtom, (optics) =>
 	optics.prop("showExpandableToolbar"),
+);
+
+export const DeleteWithNotesAtom = focusAtom(
+	settingStateAtom,
+	(optics) => optics.prop("deleteCategoryWithNotes"),
 );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,6 +79,7 @@ export interface NoteState {
 
 export interface SettingsState {
 	showExpandableToolbar: boolean;
+	deleteCategoryWithNotes: boolean;
 }
 
 export interface SyncState {


### PR DESCRIPTION
### TL;DR

Added a new preference option to delete notes associated with a category when deleting the category.

### What changed?

- Added a new switch in the Preferences component to control whether notes should be deleted along with their category.
- Updated the category deletion confirmation dialog to reflect the new preference.
- Added a new atom `DeleteWithNotesAtom` to manage the state of this preference.
- Updated the `SettingsState` interface to include the new `deleteCategoryWithNotes` property.

### How to test?

1. Navigate to the Preferences section in the app.
2. Toggle the new switch "Deleting a category include notes associated with it".
3. Attempt to delete a category and verify that the confirmation dialog reflects the chosen preference.
4. Complete the deletion process and check if notes are deleted according to the preference.

### Why make this change?

This change provides users with more control over their data management. Some users may want to keep notes even after deleting a category, while others might prefer a clean deletion of both category and associated notes. This flexibility enhances user experience and allows for more personalized data handling.

---

