### PR TITLE
Implement theme switching functionality in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@radix-ui/react-switch": "^1.1.0",
 		"@radix-ui/react-tabs": "^1.1.0",
 		"@radix-ui/react-toggle": "^1.1.0",
+		"@radix-ui/react-toggle-group": "^1.1.0",
 		"@radix-ui/react-tooltip": "^1.1.2",
 		"@t3-oss/env-nextjs": "^0.8.0",
 		"@tippyjs/react": "^4.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@radix-ui/react-toggle':
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle-group':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-tooltip':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1254,6 +1257,19 @@ packages:
 
   '@radix-ui/react-tabs@1.1.0':
     resolution: {integrity: sha512-bZgOKB/LtZIij75FSuPzyEti/XBhJH52ExgtdVqjCIh+Nx/FW+LhnbXtbCzIi34ccyMsyOja8T0thCzoHFXNKA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.0':
+    resolution: {integrity: sha512-PpTJV68dZU2oqqgq75Uzto5o/XfOVgkrJ9rulVmfTKxWp3HfUjHE6CP/WLRR4AzPX9HWxw7vFow2me85Yu+Naw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5168,6 +5184,21 @@ snapshots:
       '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.57)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.57
+      '@types/react-dom': 18.2.19
+
+  '@radix-ui/react-toggle-group@1.1.0(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-context': 1.1.0(@types/react@18.2.57)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.2.57)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle': 1.1.0(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.57)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/src/components/settings/preferences.tsx
+++ b/src/components/settings/preferences.tsx
@@ -1,3 +1,6 @@
+import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
 import { Switch } from "@/ui/switch";
 import { Label } from "@/ui/label";
 import { useAtom } from "jotai";
@@ -9,21 +12,41 @@ import {
 
 export const Preferences = () => {
 	const [showToolbar, setShowToolbar] = useAtom(ShowExpandableToolbarAtom);
-	const [WithNotes, setWithNotes] = useAtom(DeleteWithNotesAtom);
+	const [withNotes, setWithNotes] = useAtom(DeleteWithNotesAtom);
+
+	const { theme, setTheme } = useTheme();
 
 	return (
 		<div className="ml-4 flex flex-col gap-y-2">
 			<h3 className="text-lg font-semibold">Preferences</h3>
-			<div className="flex flex-col gap-y-2">
-				<Label className="flex items-center justify-between gap-x-2 text-sm font-medium leading-6 text-zinc-800">
+			<div className="flex flex-col gap-y-3">
+				<Label className="flex items-center justify-between gap-x-2 text-sm font-medium leading-6">
 					<span>Show / Hide Expandable Toolbar</span>
 					<Switch checked={showToolbar} onCheckedChange={setShowToolbar} />
 				</Label>
 
-				<Label className="flex items-center justify-between gap-x-2 text-sm font-medium leading-6 text-zinc-800">
+				<Label className="flex items-center justify-between gap-x-2 text-sm font-medium leading-6">
 					<span>Deleting a category include notes associated with it</span>
-					<Switch checked={WithNotes} onCheckedChange={setWithNotes} />
+					<Switch checked={withNotes} onCheckedChange={setWithNotes} />
 				</Label>
+
+				<div className="flex items-center justify-between gap-x-2 text-sm font-medium leading-6">
+					<span>Switch theme of the application.</span>
+					<ToggleGroup
+						size="sm"
+						type="single"
+						value={theme}
+						onValueChange={setTheme}
+						className="rounded-full border p-0.5 border-neutral-200 dark:border-neutral-700"
+					>
+						<ToggleGroupItem value="light" className="rounded-full">
+							<Sun className="h-4 w-4" />
+						</ToggleGroupItem>
+						<ToggleGroupItem value="dark" className="rounded-full">
+							<Moon className="h-4 w-4" />
+						</ToggleGroupItem>
+					</ToggleGroup>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+
+import type { VariantProps } from "class-variance-authority";
+
+import { forwardRef, createContext, useContext } from "react";
+import { toggleVariants } from "@/ui/toggle";
+import { cn } from "@/lib/utils";
+
+const ToggleGroupContext = createContext<VariantProps<typeof toggleVariants>>({
+	size: "default",
+	variant: "default",
+});
+
+const ToggleGroup = forwardRef<
+	React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+	React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
+		VariantProps<typeof toggleVariants>
+>(({ className, variant, size, children, ...props }, ref) => (
+	<ToggleGroupPrimitive.Root
+		ref={ref}
+		className={cn("flex items-center justify-center gap-1", className)}
+		{...props}
+	>
+		<ToggleGroupContext.Provider value={{ variant, size }}>
+			{children}
+		</ToggleGroupContext.Provider>
+	</ToggleGroupPrimitive.Root>
+));
+
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
+
+const ToggleGroupItem = forwardRef<
+	React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+	React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+		VariantProps<typeof toggleVariants>
+>(({ className, children, variant, size, ...props }, ref) => {
+	const context = useContext(ToggleGroupContext);
+
+	return (
+		<ToggleGroupPrimitive.Item
+			ref={ref}
+			className={cn(
+				toggleVariants({
+					variant: context.variant || variant,
+					size: context.size || size,
+				}),
+				className,
+			)}
+			{...props}
+		>
+			{children}
+		</ToggleGroupPrimitive.Item>
+	);
+});
+
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName;
+
+export { ToggleGroup, ToggleGroupItem };


### PR DESCRIPTION
### TL;DR

Added theme switching functionality to the preferences section.

### What changed?

- Introduced a new `ToggleGroup` component for theme switching
- Added `@radix-ui/react-toggle-group` dependency
- Updated the Preferences component to include a theme switcher
- Created a new `toggle-group.tsx` file with ToggleGroup and ToggleGroupItem components

### How to test?

1. Navigate to the preferences section
2. Locate the new "Switch theme of the application" option
3. Click on the sun icon to switch to light theme
4. Click on the moon icon to switch to dark theme
5. Verify that the application's theme changes accordingly

### Why make this change?

This change enhances user experience by allowing them to switch between light and dark themes directly from the preferences section. It provides better accessibility and customization options for users who prefer different visual modes depending on their environment or personal preference.

---

